### PR TITLE
WFJB2-100: Refactor DI binding keys to constants 

### DIFF
--- a/api/src/auth/auth-strategies/jwt-strategy.ts
+++ b/api/src/auth/auth-strategies/jwt-strategy.ts
@@ -3,12 +3,13 @@ import {UserProfile} from '@loopback/security';
 import {HttpErrors, RedirectRoute, Request} from '@loopback/rest';
 import {inject} from '@loopback/core';
 import {JwtService} from '../../services';
+import { BindingKeys } from '../../constants/binding-keys';
 
 export class FSAEJwtStrategy implements AuthenticationStrategy {
   name = 'fsae-jwt';
 
   constructor(
-    @inject('services.JwtService') public JwtService: JwtService
+    @inject(BindingKeys.JWT_SERVICE) public JwtService: JwtService
   ) {}
 
   authenticate(request: Request): Promise<UserProfile | RedirectRoute | undefined> {

--- a/api/src/constants/binding-keys.ts
+++ b/api/src/constants/binding-keys.ts
@@ -1,0 +1,5 @@
+export const BindingKeys = {
+    JWT_SERVICE: 'services.JwtService',
+    PASSWORD_HASHER: 'services.passwordhasher',
+  };
+  

--- a/api/src/controllers/login.controller.ts
+++ b/api/src/controllers/login.controller.ts
@@ -12,6 +12,7 @@ import {AdminRepository, AlumniRepository, MemberRepository, SponsorRepository} 
 import {FsaeUser} from '../models';
 import {JwtService, PasswordHasherService} from '../services';
 import {UserProfile} from '@loopback/security';
+import { BindingKeys } from '../constants/binding-keys';
 
 export class LoginController {
   constructor(
@@ -19,8 +20,8 @@ export class LoginController {
     @repository(AlumniRepository) private alumniRepository: AlumniRepository,
     @repository(MemberRepository) private memberRepository: MemberRepository,
     @repository(SponsorRepository) private sponsorRepository: SponsorRepository,
-    @inject('services.jwtservice') private jwtService: JwtService,
-    @inject('services.passwordhasher') private passwordHasher: PasswordHasherService
+    @inject(BindingKeys.JWT_SERVICE) private jwtService: JwtService,
+    @inject(BindingKeys.PASSWORD_HASHER) private passwordHasher: PasswordHasherService
   ) {}
 
   @post('/login-admin')

--- a/api/src/controllers/register.controller.ts
+++ b/api/src/controllers/register.controller.ts
@@ -10,6 +10,7 @@ import {createFSAEUserDto} from './controller-types/register.controller.types';
 import {Admin, FsaeRole} from '../models';
 import {inject} from '@loopback/core';
 import {PasswordHasherService} from '../services';
+import { BindingKeys } from '../constants/binding-keys';
 
 export class RegisterController {
   constructor(
@@ -17,7 +18,7 @@ export class RegisterController {
     @repository(AlumniRepository) private alumniRepository: AlumniRepository,
     @repository(MemberRepository) private memberRepository: MemberRepository,
     @repository(SponsorRepository) private sponsorRepository: SponsorRepository,
-    @inject('services.passwordhasher') private passwordHasher: PasswordHasherService
+    @inject(BindingKeys.PASSWORD_HASHER) private passwordHasher: PasswordHasherService
   ) {}
 
   @post('/register-admin')


### PR DESCRIPTION
## Context

Refactors the dependency injection (DI) binding keys to use constants instead of hard-coded strings.

## What Changed?

- Created binding-keys.ts to store the JwtService and PasswordHasherService binding keys as constants
- Updated jwt-strategy.ts, login.controller.ts, and register.controller.ts to use these constants instead of hardcoded string values for di
