### PR TITLE
Fix bug in FsaeAuthorizationProvider

### DIFF
--- a/api/src/auth/authorization/FsaeAuthorizationProvider.ts
+++ b/api/src/auth/authorization/FsaeAuthorizationProvider.ts
@@ -12,17 +12,17 @@ export class FsaeAuthorizationProvider implements Provider<Authorizer> {
     context: AuthorizationContext,
     metadata: AuthorizationMetadata,
   ) {
-    const jwtBody = context.principals[0]
+    const userProfile = context.principals[0]
 
     // Only allow activated users unless scope includes 'allow-non-activated'
-    if (!jwtBody.activated) {
+    if (!userProfile.activated) {
       if (!metadata.scopes || !metadata.scopes.includes('allow-non-activated')) {
         return AuthorizationDecision.DENY;
       }
     }
 
     // Check if role alllowed
-    const clientRole = jwtBody.role;
+    const clientRole = userProfile.fsaeRole;
     const allowedRoles = metadata.allowedRoles;
     if (allowedRoles === undefined || allowedRoles.length === 0) {
       return AuthorizationDecision.DENY


### PR DESCRIPTION


## Context

FsaeAuthorizationProvider had a bug where it tries to access `jwtBody.role` which is undefined. As a result any auth role checks would auto deny. While `.role` is the correct field of the JWT, `jwtBody` is not actually a JWT object but rather a user profile, with field name `.fsaeRole` instead of `.role`.

## What Changed?

Fixed so that .fsaeRole is accessed instead and renamed `jwtBody` to `userProfile` to better reflect that the field names are not the same as that of the JWT.


## How To Review

<!-- What (rough) order should the reviewer view your files? -->

## Testing

Tested the `GET /user/member/{id}` endpoint and no longer received 403 error while authenticated with a member account

## Risks

Since the changes only affect logic within this file it should be all good. 

## Notes

We should probably consider standardising field names across JWT object and the auth profile objects