### PR TITLE
Fix user id parameter types so that they are strings 

### DIFF
--- a/api/src/auth/authorization/FsaeAuthorizationProvider.ts
+++ b/api/src/auth/authorization/FsaeAuthorizationProvider.ts
@@ -12,17 +12,17 @@ export class FsaeAuthorizationProvider implements Provider<Authorizer> {
     context: AuthorizationContext,
     metadata: AuthorizationMetadata,
   ) {
-    const jwtBody = context.principals[0]
+    const userProfile = context.principals[0]
 
     // Only allow activated users unless scope includes 'allow-non-activated'
-    if (!jwtBody.activated) {
+    if (!userProfile.activated) {
       if (!metadata.scopes || !metadata.scopes.includes('allow-non-activated')) {
         return AuthorizationDecision.DENY;
       }
     }
 
     // Check if role alllowed
-    const clientRole = jwtBody.role;
+    const clientRole = userProfile.fsaeRole;
     const allowedRoles = metadata.allowedRoles;
     if (allowedRoles === undefined || allowedRoles.length === 0) {
       return AuthorizationDecision.DENY

--- a/api/src/controllers/activation.controller.ts
+++ b/api/src/controllers/activation.controller.ts
@@ -49,7 +49,7 @@ export class ActivationController {
     description: 'Check if alumni is activated',
     content: { 'application/json': { schema: { type: 'boolean' } } },
   })
-  async isAlumniActivated(@param.path.number('id') id: number): Promise<boolean> {
+  async isAlumniActivated(@param.path.string('id') id: string): Promise<boolean> {
     const alumni = await this.alumniRepository.findById(id);
     if (!alumni) {
       throw new HttpErrors.NotFound(`Alumni with id ${id} not found.`);
@@ -67,7 +67,7 @@ export class ActivationController {
     description: 'Check if sponsor is activated',
     content: { 'application/json': { schema: { type: 'boolean' } } },
   })
-  async isSponsorActivated(@param.path.number('id') id: number): Promise<boolean> {
+  async isSponsorActivated(@param.path.string('id') id: string): Promise<boolean> {
     const sponsor = await this.sponsorRepository.findById(id);
     if (!sponsor) {
       throw new HttpErrors.NotFound(`Sponsor with id ${id} not found.`);
@@ -86,7 +86,7 @@ export class ActivationController {
     description: 'Check if member is activated',
     content: { 'application/json': { schema: { type: 'boolean' } } },
   })
-  async isMemberActivated(@param.path.number('id') id: number): Promise<boolean> {
+  async isMemberActivated(@param.path.string('id') id: string): Promise<boolean> {
     const member = await this.memberRepository.findById(id);
     if (!member) {
       throw new HttpErrors.NotFound(`Member with id ${id} not found.`);
@@ -103,7 +103,7 @@ export class ActivationController {
   @response(204, {
     description: 'Activate alumni',
   })
-  async activateAlumni(@param.path.number('id') id: number): Promise<void> {
+  async activateAlumni(@param.path.string('id') id: string): Promise<void> {
     await this.alumniRepository.updateById(id, { activated: true });
   }
 
@@ -116,7 +116,7 @@ export class ActivationController {
   @response(204, {
     description: 'Deactivate alumni',
   })
-  async deactivateAlumni(@param.path.number('id') id: number): Promise<void> {
+  async deactivateAlumni(@param.path.string('id') id: string): Promise<void> {
     await this.alumniRepository.updateById(id, { activated: false });
   }
 
@@ -129,7 +129,7 @@ export class ActivationController {
   @response(204, {
     description: 'Activate sponsor',
   })
-  async activateSponsor(@param.path.number('id') id: number): Promise<void> {
+  async activateSponsor(@param.path.string('id') id: string): Promise<void> {
     await this.sponsorRepository.updateById(id, { activated: true });
   }
 
@@ -142,7 +142,7 @@ export class ActivationController {
   @response(204, {
     description: 'Deactivate sponsor',
   })
-  async deactivateSponsor(@param.path.number('id') id: number): Promise<void> {
+  async deactivateSponsor(@param.path.string('id') id: string): Promise<void> {
     await this.sponsorRepository.updateById(id, { activated: false });
   }
 
@@ -155,7 +155,7 @@ export class ActivationController {
   @response(204, {
     description: 'Activate member',
   })
-  async activateMember(@param.path.number('id') id: number): Promise<void> {
+  async activateMember(@param.path.string('id') id: string): Promise<void> {
     await this.memberRepository.updateById(id, { activated: true });
   }
 
@@ -168,7 +168,7 @@ export class ActivationController {
   @response(204, {
     description: 'Deactivate member',
   })
-  async deactivateMember(@param.path.number('id') id: number): Promise<void> {
+  async deactivateMember(@param.path.string('id') id: string): Promise<void> {
     await this.memberRepository.updateById(id, { activated: false });
   }
 }

--- a/api/src/controllers/alumni.controller.ts
+++ b/api/src/controllers/alumni.controller.ts
@@ -42,7 +42,7 @@ export class AlumniController {
     },
   })
   async findById(
-    @param.path.number('id') id: number,
+    @param.path.string('id') id: string,
     @param.filter(Alumni, {exclude: 'where'}) filter?: FilterExcludingWhere<Alumni>
   ): Promise<Alumni> {
     return this.alumniRepository.findById(id, filter);
@@ -56,7 +56,7 @@ export class AlumniController {
     description: 'Alumni PATCH success',
   })
   async updateById(
-    @param.path.number('id') id: number,
+    @param.path.string('id') id: string,
     @requestBody({
       content: {
         'application/json': {
@@ -76,7 +76,7 @@ export class AlumniController {
   @response(204, {
     description: 'Alumni DELETE success',
   })
-  async deleteById(@param.path.number('id') id: number): Promise<void> {
+  async deleteById(@param.path.string('id') id: string): Promise<void> {
     await this.alumniRepository.deleteById(id);
   }
 }

--- a/api/src/controllers/member.controller.ts
+++ b/api/src/controllers/member.controller.ts
@@ -42,9 +42,10 @@ export class MemberController {
     },
   })
   async findById(
-    @param.path.number('id') id: number,
+    @param.path.string('id') id: string,
     @param.filter(Member, {exclude: 'where'}) filter?: FilterExcludingWhere<Member>
-  ): Promise<Member> {
+  ): Promise<Member | null> {
+
     return this.memberRepository.findById(id, filter);
   }
 
@@ -56,7 +57,7 @@ export class MemberController {
     description: 'Member PATCH success',
   })
   async updateById(
-    @param.path.number('id') id: number,
+    @param.path.string('id') id: string,
     @requestBody({
       content: {
         'application/json': {
@@ -76,7 +77,7 @@ export class MemberController {
   @response(204, {
     description: 'Member DELETE success',
   })
-  async deleteById(@param.path.number('id') id: number): Promise<void> {
+  async deleteById(@param.path.string('id') id: string): Promise<void> {
     await this.memberRepository.deleteById(id);
   }
 }

--- a/api/src/controllers/sponsor.controller.ts
+++ b/api/src/controllers/sponsor.controller.ts
@@ -42,7 +42,7 @@ export class SponsorController {
     },
   })
   async findById(
-    @param.path.number('id') id: number,
+    @param.path.string('id') id: string,
     @param.filter(Sponsor, {exclude: 'where'}) filter?: FilterExcludingWhere<Sponsor>
   ): Promise<Sponsor> {
     return this.sponsorRepository.findById(id, filter);
@@ -56,7 +56,7 @@ export class SponsorController {
     description: 'Sponsor PATCH success',
   })
   async updateById(
-    @param.path.number('id') id: number,
+    @param.path.string('id') id: string,
     @requestBody({
       content: {
         'application/json': {
@@ -76,7 +76,7 @@ export class SponsorController {
   @response(204, {
     description: 'Sponsor DELETE success',
   })
-  async deleteById(@param.path.number('id') id: number): Promise<void> {
+  async deleteById(@param.path.string('id') id: string): Promise<void> {
     await this.sponsorRepository.deleteById(id);
   }
 }

--- a/api/src/models/alumni.model.ts
+++ b/api/src/models/alumni.model.ts
@@ -4,11 +4,11 @@ import {FsaeUser} from './index';
 @model({settings: {strict: false}})
 export class Alumni extends FsaeUser {
   @property({
-    type: 'number',
+    type: 'string',
     id: true,
     generated: true,
   })
-  alumniID?: number;
+  alumniID?: string;
 
   @property({
     type: 'string',

--- a/api/src/models/member.model.ts
+++ b/api/src/models/member.model.ts
@@ -4,11 +4,11 @@ import {FsaeUser} from './fsae-user.model';
 @model({settings: {strict: false}})
 export class Member extends FsaeUser {
   @property({
-    type: 'number',
+    type: 'string',
     id: true,
     generated: true,
   })
-  memberID?: number;
+  memberID?: string;
 
   @property({
     type: 'string',

--- a/api/src/models/sponsor.model.ts
+++ b/api/src/models/sponsor.model.ts
@@ -4,11 +4,11 @@ import {FsaeUser} from './fsae-user.model';
 @model({settings: {strict: false}})
 export class Sponsor extends FsaeUser {
   @property({
-    type: 'number',
+    type: 'string',
     id: true,
     generated: true,
   })
-  sponsorID?: number;
+  sponsorID?: string;
 
   @property({
     type: 'string',


### PR DESCRIPTION
## Context

For some reason, all endpoints that required a user id (eg. for finding members/alumni/sponsors by id) had their `id` parameter typed as a `number`, when internally ids are represented as a hex `string`. I believe this was a holdover from numerical `memberID`, `sponsorID` and `alumniID` fields, which remain optional in their respective models and are otherwise unused in the codebase.

## What Changed?

`id` parameters across any affected controllers have been re-typed to be strings.
Models that inherit from `FsaeUser` have had their respective optional ids re-typed to strings, although they remain unused since the inherited `id` from `FsaeUser` is what is actually used as the model's primary key.

This branch also has changes identical to the [FsaeAuthorizationProvider bug fix](https://github.com/UoaWDCC/fsae-jobs-board/pull/97) as that bug fix is required to test and use the endpoints that this bug fix applies to.

## How To Review

Make sure to review [my other PR](https://github.com/UoaWDCC/fsae-jobs-board/pull/97) first

## Testing

Tested the `GET /user/member/{id}` endpoint and was able to successfully retrieve a member by id.
Other endpoints remain untested but I have tried to be consistent with my changes.

## Risks

If I have misunderstood something, and there is a reason for these ids to be typed as numbers.. but I don't believe this is the case.

## Notes

We could consider removing `memberID`, `sponsorID`, and `alumniID` from their respective models if we aren't planning to use them. I don't see why we would as each type of member inherits a primary key `id` from`FsaeUser` anyways.