### PR TITLE
WJFB2-99 whoami endpoint

### DIFF
--- a/api/src/controllers/controller-types/login.controller.types.ts
+++ b/api/src/controllers/controller-types/login.controller.types.ts
@@ -8,3 +8,11 @@ export type loginResponse = {
   token: string,
   verified: boolean;
 }
+
+export type whoAmIResponse = {
+  id: string,
+  firstName: string,
+  lastName: string,
+  email: string,
+  role: string,
+}

--- a/api/src/controllers/login.controller.ts
+++ b/api/src/controllers/login.controller.ts
@@ -16,6 +16,7 @@ import {authenticate} from '@loopback/authentication';
 import {
   loginParams,
   loginResponse,
+  whoAmIResponse,
 } from './controller-types/login.controller.types';
 import {inject, service} from '@loopback/core';
 import {repository} from '@loopback/repository';
@@ -183,7 +184,6 @@ export class LoginController {
     return this.fsaeUserService.getUserRole(userEmail);
   }
 
-  //make a custom return type for the response??
   @get('/user/whoami')
   @authenticate('fsae-jwt')
   @authorize({
@@ -213,7 +213,7 @@ export class LoginController {
   })
   async whoAmI(
     @inject(SecurityBindings.USER) currentUser: UserProfile,
-  ): Promise<object> {
+  ): Promise<whoAmIResponse> {
     const userId = currentUser.id;
     const role = currentUser.fsaeRole;
 
@@ -232,12 +232,13 @@ export class LoginController {
         user = await this.memberRepository.findById(userId);
         break;
       default:
-        throw new HttpErrors.Unauthorized('Unrecognized role');
+        throw new HttpErrors.InternalServerError('Unrecognized role');
     }
 
     return {
       id: user.id,
-      name: user.firstName + ' ' + user.lastName,
+      firstName: user.firstName,
+      lastName: user.lastName,
       email: user.email,
       role: role,
     };

--- a/api/src/models/alumni.model.ts
+++ b/api/src/models/alumni.model.ts
@@ -14,13 +14,13 @@ export class Alumni extends FsaeUser {
     type: 'string',
     required: false,
   })
-  subGroup: string;
+  subGroup?: string;
 
   @property({
     type: 'string',
     required: false,
   })
-  company: string;
+  company?: string;
 
   // Indexer property to allow additional data
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/api/src/models/fsae-user.model.ts
+++ b/api/src/models/fsae-user.model.ts
@@ -9,7 +9,7 @@ export abstract class FsaeUser extends Entity {
     id: true,
     generated: true,
   })
-  id?: string;
+  id: string;
 
   @property({
     type: 'string',
@@ -53,21 +53,25 @@ export abstract class FsaeUser extends Entity {
 
   @property({
     type: 'string',
+    required: true,
   })
-  firstName?: string;
+  firstName: string;
 
   @property({
     type: 'string',
+    required: true,
   })
-  lastName?: string;
+  lastName: string;
 
   @property({
     type: 'string',
+    required: true,
   })
-  phoneNumber?: string;
+  phoneNumber: string;
 
   @property({
     type: 'string',
+    required: false,
   })
   desc?: string;
 

--- a/api/src/models/member.model.ts
+++ b/api/src/models/member.model.ts
@@ -14,19 +14,19 @@ export class Member extends FsaeUser {
     type: 'string',
     required: false,
   })
-  cv: string;
+  cv?: string;
 
   @property({
     type: 'string',
     required: false,
   })
-  subGroup: string;
+  subGroup?: string;
 
   @property({
     type: 'string',
     required: false,
   })
-  photo: string;
+  photo?: string;
 
   // Indexer property to allow additional data
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/api/src/models/sponsor.model.ts
+++ b/api/src/models/sponsor.model.ts
@@ -14,37 +14,37 @@ export class Sponsor extends FsaeUser {
     type: 'string',
     required: false,
   })
-  logo: string;
+  logo?: string;
 
   @property({
     type: 'string',
     required: false,
   })
-  websiteURL: string;
+  websiteURL?: string;
 
   @property({
     type: 'string',
     required: false,
   })
-  tier: string;
+  tier?: string;
 
   @property({
     type: 'string',
     required: false,
   })
-  name: string;
+  name?: string;
 
   @property({
     type: 'string',
     required: false,
   })
-  industry: string;
+  industry?: string;
 
   @property({
     type: 'string',
     required: false,
   })
-  company: string;
+  company?: string;
 
   // Indexer property to allow additional data
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Context
To enhance user identity verification in the project, we need to implement API endpoints for the WhoAmI feature. These endpoints will allow authenticated users to retrieve their own profile information, helping them verify their identity and access their details securely. This information will also be locally stored for further reference.

See ticket WFJB2-99

## What Changed?

We implemented a `/user/whoami` endpoint in the login controller, with its own response type.

Also made the optional/required type of each model field be consistent with whether it is optional/required in the actual mongo model. Made best guesses for fields that did not specify optional/required.

## How To Review

<!-- What (rough) order should the reviewer view your files? -->

## Testing

Manually tested with a logged in member.

## Risks

<!-- Where should the reviewer focus on (if any)? -->

## Notes