### PR TITLE
WFJB2-79 Routes for applications

### DIFF
--- a/api/src/controllers/application.controller.ts
+++ b/api/src/controllers/application.controller.ts
@@ -16,17 +16,31 @@ import {
   del,
   requestBody,
   response,
+  HttpErrors
 } from '@loopback/rest';
 import {Application} from '../models';
-import {ApplicationRepository} from '../repositories';
+import {ApplicationRepository, JobAdRepository, MemberRepository} from '../repositories';
+import {authenticate, AuthenticationBindings} from '@loopback/authentication';
+import {authorize} from '@loopback/authorization';
+import {inject} from '@loopback/core';
+import {UserProfile} from '@loopback/security';
+import {FsaeRole} from '../models';
 
 export class ApplicationController {
   constructor(
     @repository(ApplicationRepository)
-    public applicationRepository : ApplicationRepository,
+    public applicationRepository: ApplicationRepository,
+    @repository(JobAdRepository)
+    public jobAdRepository: JobAdRepository,
+    @repository(MemberRepository)
+    public memberRepository: MemberRepository,
   ) {}
 
-  @post('/application') //keep
+  @authenticate('fsae-jwt')
+  @authorize({
+    allowedRoles: [FsaeRole.MEMBER],
+  })
+  @post('/application') //auto assign date on server side?
   @response(200, {
     description: 'Application model instance',
     content: {'application/json': {schema: getModelSchemaRef(Application)}},
@@ -37,26 +51,64 @@ export class ApplicationController {
         'application/json': {
           schema: getModelSchemaRef(Application, {
             title: 'NewApplication',
-            exclude: ['id'],
+            exclude: ['id', 'memberID'],
           }),
         },
       },
     })
-    application: Omit<Application, 'id'>,
+    application: Omit<Application, 'id' | 'memberID'>,
+    @inject(AuthenticationBindings.CURRENT_USER) currentUser: UserProfile,
   ): Promise<Application> {
-    return this.applicationRepository.create(application);
-  }
+    try {
+      // Input validation
+      if (!application.jobID || typeof application.jobID !== 'string' || application.jobID.trim() === '') {
+        throw new HttpErrors.BadRequest('jobID is required and must be a non-empty string.');
+      }
+      if (!application.status || typeof application.status !== 'string' || application.status.trim() === '') {
+        throw new HttpErrors.BadRequest('status is required and must be a non-empty string.');
+      }
+      if (!application.applicationDate || typeof application.applicationDate !== 'string' || application.applicationDate.trim() === '') {
+        throw new HttpErrors.BadRequest('applicationDate is required and must be a non-empty string.');
+      }
 
-  // @get('/application/count')
-  // @response(200, {
-  //   description: 'Application model count',
-  //   content: {'application/json': {schema: CountSchema}},
-  // })
-  // async count(
-  //   @param.where(Application) where?: Where<Application>,
-  // ): Promise<Count> {
-  //   return this.applicationRepository.count(where);
-  // }
+
+      const newApplication = {
+        ...application,
+        memberID: currentUser.id,
+      };
+
+
+      const existing = await this.applicationRepository.findOne({
+        where: {
+          memberID: newApplication.memberID,
+          jobID: newApplication.jobID,
+        },
+      });
+      if (existing) {
+        throw new HttpErrors.Conflict('You have already applied to this job.');
+      }
+
+
+      try {
+        await this.jobAdRepository.findById(newApplication.jobID);
+      } catch {
+        throw new HttpErrors.NotFound('The specified job does not exist.');
+      }
+
+
+      try {
+        await this.memberRepository.findById(newApplication.memberID);
+      } catch {
+        throw new HttpErrors.NotFound('The specified member does not exist.');
+      }
+
+
+      return await this.applicationRepository.create(newApplication);
+    } catch (err) {
+      if (err instanceof HttpErrors.HttpError) throw err;
+      throw new HttpErrors.InternalServerError('Failed to create application');
+    }
+  }
 
   @get('/application')
   @response(200, {
@@ -75,25 +127,6 @@ export class ApplicationController {
   ): Promise<Application[]> {
     return this.applicationRepository.find(filter);
   }
-
-  // @patch('/application')
-  // @response(200, {
-  //   description: 'Application PATCH success count',
-  //   content: {'application/json': {schema: CountSchema}},
-  // })
-  // async updateAll(
-  //   @requestBody({
-  //     content: {
-  //       'application/json': {
-  //         schema: getModelSchemaRef(Application, {partial: true}),
-  //       },
-  //     },
-  //   })
-  //   application: Application,
-  //   @param.where(Application) where?: Where<Application>,
-  // ): Promise<Count> {
-  //   return this.applicationRepository.updateAll(application, where);
-  // }
 
   @get('/application/{id}')
   @response(200, {
@@ -128,17 +161,6 @@ export class ApplicationController {
   ): Promise<void> {
     await this.applicationRepository.updateById(id, application);
   }
-
-  // @put('/application/{id}')
-  // @response(204, {
-  //   description: 'Application PUT success',
-  // })
-  // async replaceById(
-  //   @param.path.string('id') id: string,
-  //   @requestBody() application: Application,
-  // ): Promise<void> {
-  //   await this.applicationRepository.replaceById(id, application);
-  // }
 
   @del('/application/{id}')
   @response(204, {

--- a/api/src/controllers/application.controller.ts
+++ b/api/src/controllers/application.controller.ts
@@ -26,7 +26,7 @@ export class ApplicationController {
     public applicationRepository : ApplicationRepository,
   ) {}
 
-  @post('/application')
+  @post('/application') //keep
   @response(200, {
     description: 'Application model instance',
     content: {'application/json': {schema: getModelSchemaRef(Application)}},
@@ -47,16 +47,16 @@ export class ApplicationController {
     return this.applicationRepository.create(application);
   }
 
-  @get('/application/count')
-  @response(200, {
-    description: 'Application model count',
-    content: {'application/json': {schema: CountSchema}},
-  })
-  async count(
-    @param.where(Application) where?: Where<Application>,
-  ): Promise<Count> {
-    return this.applicationRepository.count(where);
-  }
+  // @get('/application/count')
+  // @response(200, {
+  //   description: 'Application model count',
+  //   content: {'application/json': {schema: CountSchema}},
+  // })
+  // async count(
+  //   @param.where(Application) where?: Where<Application>,
+  // ): Promise<Count> {
+  //   return this.applicationRepository.count(where);
+  // }
 
   @get('/application')
   @response(200, {
@@ -76,24 +76,24 @@ export class ApplicationController {
     return this.applicationRepository.find(filter);
   }
 
-  @patch('/application')
-  @response(200, {
-    description: 'Application PATCH success count',
-    content: {'application/json': {schema: CountSchema}},
-  })
-  async updateAll(
-    @requestBody({
-      content: {
-        'application/json': {
-          schema: getModelSchemaRef(Application, {partial: true}),
-        },
-      },
-    })
-    application: Application,
-    @param.where(Application) where?: Where<Application>,
-  ): Promise<Count> {
-    return this.applicationRepository.updateAll(application, where);
-  }
+  // @patch('/application')
+  // @response(200, {
+  //   description: 'Application PATCH success count',
+  //   content: {'application/json': {schema: CountSchema}},
+  // })
+  // async updateAll(
+  //   @requestBody({
+  //     content: {
+  //       'application/json': {
+  //         schema: getModelSchemaRef(Application, {partial: true}),
+  //       },
+  //     },
+  //   })
+  //   application: Application,
+  //   @param.where(Application) where?: Where<Application>,
+  // ): Promise<Count> {
+  //   return this.applicationRepository.updateAll(application, where);
+  // }
 
   @get('/application/{id}')
   @response(200, {
@@ -129,16 +129,16 @@ export class ApplicationController {
     await this.applicationRepository.updateById(id, application);
   }
 
-  @put('/application/{id}')
-  @response(204, {
-    description: 'Application PUT success',
-  })
-  async replaceById(
-    @param.path.string('id') id: string,
-    @requestBody() application: Application,
-  ): Promise<void> {
-    await this.applicationRepository.replaceById(id, application);
-  }
+  // @put('/application/{id}')
+  // @response(204, {
+  //   description: 'Application PUT success',
+  // })
+  // async replaceById(
+  //   @param.path.string('id') id: string,
+  //   @requestBody() application: Application,
+  // ): Promise<void> {
+  //   await this.applicationRepository.replaceById(id, application);
+  // }
 
   @del('/application/{id}')
   @response(204, {

--- a/api/src/controllers/application.controller.ts
+++ b/api/src/controllers/application.controller.ts
@@ -1,0 +1,150 @@
+import {
+  Count,
+  CountSchema,
+  Filter,
+  FilterExcludingWhere,
+  repository,
+  Where,
+} from '@loopback/repository';
+import {
+  post,
+  param,
+  get,
+  getModelSchemaRef,
+  patch,
+  put,
+  del,
+  requestBody,
+  response,
+} from '@loopback/rest';
+import {Application} from '../models';
+import {ApplicationRepository} from '../repositories';
+
+export class ApplicationController {
+  constructor(
+    @repository(ApplicationRepository)
+    public applicationRepository : ApplicationRepository,
+  ) {}
+
+  @post('/application')
+  @response(200, {
+    description: 'Application model instance',
+    content: {'application/json': {schema: getModelSchemaRef(Application)}},
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Application, {
+            title: 'NewApplication',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    application: Omit<Application, 'id'>,
+  ): Promise<Application> {
+    return this.applicationRepository.create(application);
+  }
+
+  @get('/application/count')
+  @response(200, {
+    description: 'Application model count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async count(
+    @param.where(Application) where?: Where<Application>,
+  ): Promise<Count> {
+    return this.applicationRepository.count(where);
+  }
+
+  @get('/application')
+  @response(200, {
+    description: 'Array of Application model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(Application, {includeRelations: true}),
+        },
+      },
+    },
+  })
+  async find(
+    @param.filter(Application) filter?: Filter<Application>,
+  ): Promise<Application[]> {
+    return this.applicationRepository.find(filter);
+  }
+
+  @patch('/application')
+  @response(200, {
+    description: 'Application PATCH success count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async updateAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Application, {partial: true}),
+        },
+      },
+    })
+    application: Application,
+    @param.where(Application) where?: Where<Application>,
+  ): Promise<Count> {
+    return this.applicationRepository.updateAll(application, where);
+  }
+
+  @get('/application/{id}')
+  @response(200, {
+    description: 'Application model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(Application, {includeRelations: true}),
+      },
+    },
+  })
+  async findById(
+    @param.path.string('id') id: string,
+    @param.filter(Application, {exclude: 'where'}) filter?: FilterExcludingWhere<Application>
+  ): Promise<Application> {
+    return this.applicationRepository.findById(id, filter);
+  }
+
+  @patch('/application/{id}')
+  @response(204, {
+    description: 'Application PATCH success',
+  })
+  async updateById(
+    @param.path.string('id') id: string,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Application, {partial: true}),
+        },
+      },
+    })
+    application: Application,
+  ): Promise<void> {
+    await this.applicationRepository.updateById(id, application);
+  }
+
+  @put('/application/{id}')
+  @response(204, {
+    description: 'Application PUT success',
+  })
+  async replaceById(
+    @param.path.string('id') id: string,
+    @requestBody() application: Application,
+  ): Promise<void> {
+    await this.applicationRepository.replaceById(id, application);
+  }
+
+  @del('/application/{id}')
+  @response(204, {
+    description: 'Application DELETE success',
+  })
+  async deleteById(@param.path.string('id') id: string): Promise<void> {
+    await this.applicationRepository.deleteById(id);
+  }
+}

--- a/api/src/controllers/application.controller.ts
+++ b/api/src/controllers/application.controller.ts
@@ -16,10 +16,14 @@ import {
   del,
   requestBody,
   response,
-  HttpErrors
+  HttpErrors,
 } from '@loopback/rest';
 import {Application} from '../models';
-import {ApplicationRepository, JobAdRepository, MemberRepository} from '../repositories';
+import {
+  ApplicationRepository,
+  JobAdRepository,
+  MemberRepository,
+} from '../repositories';
 import {authenticate, AuthenticationBindings} from '@loopback/authentication';
 import {authorize} from '@loopback/authorization';
 import {inject} from '@loopback/core';
@@ -63,22 +67,38 @@ export class ApplicationController {
   ): Promise<Application> {
     try {
       // Input validation
-      if (!application.jobID || typeof application.jobID !== 'string' || application.jobID.trim() === '') {
-        throw new HttpErrors.BadRequest('jobID is required and must be a non-empty string.');
+      if (
+        !application.jobID ||
+        typeof application.jobID !== 'string' ||
+        application.jobID.trim() === ''
+      ) {
+        throw new HttpErrors.BadRequest(
+          'jobID is required and must be a non-empty string.',
+        );
       }
-      if (!application.status || typeof application.status !== 'string' || application.status.trim() === '') {
-        throw new HttpErrors.BadRequest('status is required and must be a non-empty string.');
+      if (
+        !application.status ||
+        typeof application.status !== 'string' ||
+        application.status.trim() === ''
+      ) {
+        throw new HttpErrors.BadRequest(
+          'status is required and must be a non-empty string.',
+        );
       }
-      if (!application.applicationDate || typeof application.applicationDate !== 'string' || application.applicationDate.trim() === '') {
-        throw new HttpErrors.BadRequest('applicationDate is required and must be a non-empty string.');
+      if (
+        !application.applicationDate ||
+        typeof application.applicationDate !== 'string' ||
+        application.applicationDate.trim() === ''
+      ) {
+        throw new HttpErrors.BadRequest(
+          'applicationDate is required and must be a non-empty string.',
+        );
       }
-
 
       const newApplication = {
         ...application,
         memberID: currentUser.id,
       };
-
 
       const existing = await this.applicationRepository.findOne({
         where: {
@@ -90,20 +110,17 @@ export class ApplicationController {
         throw new HttpErrors.Conflict('You have already applied to this job.');
       }
 
-
       try {
         await this.jobAdRepository.findById(newApplication.jobID);
       } catch {
         throw new HttpErrors.NotFound('The specified job does not exist.');
       }
 
-
       try {
         await this.memberRepository.findById(newApplication.memberID);
       } catch {
         throw new HttpErrors.NotFound('The specified member does not exist.');
       }
-
 
       return await this.applicationRepository.create(newApplication);
     } catch (err) {
@@ -137,18 +154,29 @@ export class ApplicationController {
     const filter: Filter<Application> = {};
 
     let jobIDs: string[] = [];
-    if (currentUser.fsaeRole === FsaeRole.ALUMNI || currentUser.fsaeRole === FsaeRole.SPONSOR) {
-      const jobs = await this.jobAdRepository.find({where: {publisherID: currentUser.id}});
+    if (
+      currentUser.fsaeRole === FsaeRole.ALUMNI ||
+      currentUser.fsaeRole === FsaeRole.SPONSOR
+    ) {
+      const jobs = await this.jobAdRepository.find({
+        where: {publisherID: currentUser.id},
+      });
       jobIDs = jobs.map(j => j.id).filter((id): id is string => !!id);
-      filter.where = { ...(filter.where || {}), jobID: { inq: jobIDs } };
+      filter.where = {...(filter.where || {}), jobID: {inq: jobIDs}};
     }
 
     if (jobID) {
       // If alumni/sponsor ensure jobID is in their jobs
-      if ((currentUser.fsaeRole === FsaeRole.ALUMNI || currentUser.fsaeRole === FsaeRole.SPONSOR) && !jobIDs.includes(jobID)) {
-        throw new HttpErrors.Forbidden('You are not authorized to view applications for this job.');
+      if (
+        (currentUser.fsaeRole === FsaeRole.ALUMNI ||
+          currentUser.fsaeRole === FsaeRole.SPONSOR) &&
+        !jobIDs.includes(jobID)
+      ) {
+        throw new HttpErrors.Forbidden(
+          'You are not authorized to view applications for this job.',
+        );
       }
-      filter.where = { ...(filter.where || {}), jobID };
+      filter.where = {...(filter.where || {}), jobID};
     }
     if (limit !== undefined && limit > 0) filter.limit = limit;
     if (skip !== undefined && skip >= 0) filter.skip = skip;
@@ -156,6 +184,10 @@ export class ApplicationController {
     return this.applicationRepository.find(filter);
   }
 
+  @authenticate('fsae-jwt')
+  @authorize({
+    allowedRoles: [FsaeRole.SPONSOR, FsaeRole.ALUMNI],
+  })
   @get('/application/{id}')
   @response(200, {
     description: 'Application model instance',
@@ -167,9 +199,39 @@ export class ApplicationController {
   })
   async findById(
     @param.path.string('id') id: string,
-    @param.filter(Application, {exclude: 'where'}) filter?: FilterExcludingWhere<Application>
+    @inject(AuthenticationBindings.CURRENT_USER) currentUser: UserProfile,
+    @param.filter(Application, {exclude: 'where'})
+    filter?: FilterExcludingWhere<Application>,
   ): Promise<Application> {
-    return this.applicationRepository.findById(id, filter);
+    try {
+      // Get the application
+      const application = await this.applicationRepository.findById(id);
+
+      if (!application) {
+        throw new HttpErrors.NotFound('Application not found');
+      }
+
+      // Get the job ad associated with this application
+      const jobAd = await this.jobAdRepository.findById(application.jobID);
+
+      if (!jobAd) {
+        throw new HttpErrors.NotFound('Associated job ad not found');
+      }
+
+      // Check if the current user owns the job ad
+      if (jobAd.publisherID !== currentUser.id) {
+        throw new HttpErrors.Forbidden(
+          'You are not authorized to view this application',
+        );
+      }
+
+      return application;
+    } catch (error) {
+      if (error instanceof HttpErrors.HttpError) {
+        throw error;
+      }
+      throw new HttpErrors.InternalServerError('Failed to fetch application');
+    }
   }
 
   @authenticate('fsae-jwt')
@@ -201,7 +263,9 @@ export class ApplicationController {
     }
 
     if (existing.memberID?.toString() !== currentUser.id?.toString()) {
-      throw new HttpErrors.Forbidden('You are not authorized to update this application.');
+      throw new HttpErrors.Forbidden(
+        'You are not authorized to update this application.',
+      );
     }
 
     for (const field of forbiddenFields) {
@@ -217,11 +281,42 @@ export class ApplicationController {
     await this.applicationRepository.updateById(id, application);
   }
 
+  @authenticate('fsae-jwt')
+  @authorize({
+    allowedRoles: [FsaeRole.SPONSOR, FsaeRole.ALUMNI],
+  })
   @del('/application/{id}')
   @response(204, {
     description: 'Application DELETE success',
   })
-  async deleteById(@param.path.string('id') id: string): Promise<void> {
-    await this.applicationRepository.deleteById(id);
+  async deleteById(
+    @param.path.string('id') id: string,
+    @inject(AuthenticationBindings.CURRENT_USER) currentUser: UserProfile,
+  ): Promise<void> {
+    try {
+      // Get the application
+      const application = await this.applicationRepository.findById(id);
+      if (!application) {
+        throw new HttpErrors.NotFound('Application not found');
+      }
+
+      // Get the job ad associated with this application
+      const jobAd = await this.jobAdRepository.findById(application.jobID);
+      if (!jobAd) {
+        throw new HttpErrors.NotFound('Associated job ad not found');
+      }
+
+      // Check if the current user owns the job ad
+      if (jobAd.publisherID !== currentUser.id) {
+        throw new HttpErrors.Forbidden(
+          'You are not authorized to delete this application',
+        );
+      }
+
+      await this.applicationRepository.deleteById(id);
+    } catch (error) {
+      if (error instanceof HttpErrors.HttpError) throw error;
+      throw new HttpErrors.InternalServerError('Failed to delete application');
+    }
   }
 }

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -7,3 +7,4 @@ export * from './register.controller';
 export * from './job.controller';
 export * from './activation.controller';
 export * from './verification.controller';
+export * from './application.controller';

--- a/api/src/models/application.model.ts
+++ b/api/src/models/application.model.ts
@@ -1,0 +1,46 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Application extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+    generated: true,
+  })
+  id?: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  memberID: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  jobID: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  status: string;
+
+  @property({
+    type: 'date',
+    required: true,
+  })
+  applicationDate: string;
+
+
+  constructor(data?: Partial<Application>) {
+    super(data);
+  }
+}
+
+export interface ApplicationRelations {
+  // describe navigational properties here
+}
+
+export type ApplicationWithRelations = Application & ApplicationRelations;

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -8,3 +8,4 @@ export * from './alumni.model';
 export * from './job-ad.model';
 export * from './verification.model';
 export * from './passwordresets.model';
+export * from './application.model';

--- a/api/src/repositories/application.repository.ts
+++ b/api/src/repositories/application.repository.ts
@@ -1,0 +1,16 @@
+import {inject} from '@loopback/core';
+import {DefaultCrudRepository} from '@loopback/repository';
+import {MongoDbDataSource} from '../datasources';
+import {Application, ApplicationRelations} from '../models';
+
+export class ApplicationRepository extends DefaultCrudRepository<
+  Application,
+  typeof Application.prototype.id,
+  ApplicationRelations
+> {
+  constructor(
+    @inject('datasources.mongoDB') dataSource: MongoDbDataSource,
+  ) {
+    super(Application, dataSource);
+  }
+}

--- a/api/src/repositories/index.ts
+++ b/api/src/repositories/index.ts
@@ -6,3 +6,4 @@ export * from './member.repository';
 export * from './sponsor.repository';
 export * from './job-ad.repository';
 export * from './verification.repository';
+export * from './application.repository';


### PR DESCRIPTION
## Context

Implements the backend routes for managing job applications as part of the job board.
Provides endpoints for creating, retrieving (single and multiple), updating, and deleting applications, with proper authentication and authorisation.

Rules enforced:
- Only members can create and update their own applications.
- Members can only create at most 1 application per job listing
- Sponsors and alumni can only view applications for jobs they have posted
- Only sponsors/alumni can delete applications, if they were applied to a job they listed
- Field restrictions are enforced for PATCH (currently only id and memberID are immutable, but this can be extended)

These changes are required to support the application submission and management features.

Closes #79

## What Changed?

- Created application.controller.ts with all required endpoints for applications:
- POST /application
- GET /application (with pagination)
- GET /application/{id}
- PATCH /application/{id}
- DELETE /application/{id}
- Created application.model.ts defining the Application schema.
- Created application.repository.ts for Application data access.
- Implemented authentication, authorisation, and ownership checks in all endpoints.
- Used a forbiddenFields array in PATCH to restrict updates to id and memberID (can be extended as needed).

## How To Review

## Testing

- Set up a test MongoDB cluster with all relevant collections (member, alumni, sponsor, jobad, application) and documents, used job endpoints as test alumni/sponsor to create jobs; applied as test member(s)
- Verified all application endpoints (GET, POST, PATCH, DELETE) via Swagger UI for correct authentication, authorisation, and error handling

## Risks

- The PATCH endpoint currently allows members to update jobId, status, and applicationDate—this may need to be further restricted based on requirements
- If the schema changes in the future, endpoints and test data may require updates to remain compatible

## Notes

- applicationDate in test data is sometimes a string, sometimes a date object; consistency may need to be enforced
- Test data was created based on code models, not the Figma schema
