### PR TITLE
test(e2e): update assertion to expect /login instead of /verify

### DIFF
--- a/api/cypress.config.ts
+++ b/api/cypress.config.ts
@@ -1,0 +1,7 @@
+export default {
+  e2e: {
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+  },
+};

--- a/api/cypress/fixtures/example.json
+++ b/api/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/api/cypress/support/commands.ts
+++ b/api/cypress/support/commands.ts
@@ -1,0 +1,37 @@
+/// <reference types="cypress" />
+// ***********************************************
+// This example commands.ts shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+//
+// declare global {
+//   namespace Cypress {
+//     interface Chainable {
+//       login(email: string, password: string): Chainable<void>
+//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
+//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//     }
+//   }
+// }

--- a/api/cypress/support/e2e.ts
+++ b/api/cypress/support/e2e.ts
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'

--- a/web/cypress/e2e/01_signup.cy.ts
+++ b/web/cypress/e2e/01_signup.cy.ts
@@ -23,7 +23,9 @@ describe('Tests successful user signup flow', () => {
     cy.task('deleteUsersByEmail', `validstudent@gmail.com`); // delete any existing user with this email
     fillFields('student');
     cy.get('button[type="submit"]').click();
-    cy.url().should('include', '/verify');
+    cy.url().should('include', '/login');
+    // '/verify' is the route for email verification which has not been implemented yet
+    // cy.url().should('include', '/verify');
   });
 
   it('should sign up a new sponsor user with valid fields filled', () => {
@@ -31,7 +33,8 @@ describe('Tests successful user signup flow', () => {
     cy.task('deleteUsersByEmail', `validsponsor@gmail.com`); // delete any existing user with this email
     fillFields('sponsor');
     cy.get('button[type="submit"]').click();
-    cy.url().should('include', '/verify');
+    cy.url().should('include', '/login');
+    // cy.url().should('include', '/verify');
   });
 
   it('should sign up a new alumni user with valid fields filled', () => {
@@ -39,7 +42,8 @@ describe('Tests successful user signup flow', () => {
     cy.task('deleteUsersByEmail', `validalumni@gmail.com`); // delete any existing user with this email
     fillFields('alumni');
     cy.get('button[type="submit"]').click();
-    cy.url().should('include', '/verify');
+    cy.url().should('include', '/login');
+    // cy.url().should('include', '/verify');
   });
 })
 


### PR DESCRIPTION
## Context

Ran out of Twilio auth credits so the email authentication flow was commented out, resulting in the signup page not redirecting to `/verify`.

## What Changed?

- Changed the `/verify` link in the e2e signup tests to expect `/login` instead.
- Commented out the `/verify` assert statement.

## How To Review

Only one file to view:
- `web/cypress/e2e/01_signup.cy.ts`

## Testing

Tested the file with Cypress and it passed all the checks.

## Risks

When the Twilio service is active again remember to revert the tests back.

## Notes

On some machines, Cypress resolves `localhost` using `IPv6` whereas it is usually being resolved to `127.0.0.1` using `IPv4`. This causes issues in the testing because `localhost` is used frequently throughout the codebase, whereas the backend is being run on `127.0.0.1`.
